### PR TITLE
feat(auth-ui): 회원/이력 UI 페이지 추가 및 수정

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -12,7 +12,8 @@
         "react": "^19.1.1",
         "react-calendar": "^6.0.0",
         "react-dom": "^19.1.1",
-        "react-router-dom": "^7.9.2"
+        "react-router-dom": "^7.9.2",
+        "recharts": "^3.2.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
@@ -1006,6 +1007,32 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
+      "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.35",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.35.tgz",
@@ -1321,6 +1348,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1366,6 +1405,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1399,6 +1501,12 @@
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.0.3",
@@ -1719,6 +1827,127 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1736,6 +1965,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -1818,6 +2053,16 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.10",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
+      "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.10",
@@ -2061,6 +2306,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2368,6 +2619,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -2393,6 +2654,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -2874,6 +3144,36 @@
         "react": "^19.1.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2921,6 +3221,54 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.1.tgz",
+      "integrity": "sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3055,6 +3403,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3124,6 +3478,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/FE/package.json
+++ b/FE/package.json
@@ -14,7 +14,8 @@
     "react": "^19.1.1",
     "react-calendar": "^6.0.0",
     "react-dom": "^19.1.1",
-    "react-router-dom": "^7.9.2"
+    "react-router-dom": "^7.9.2",
+    "recharts": "^3.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",

--- a/FE/src/App.jsx
+++ b/FE/src/App.jsx
@@ -11,6 +11,10 @@ import Step1 from "./pages/Simulation/Step1";
 import Step2 from "./pages/Simulation/Step2";
 import Step3 from "./pages/Simulation/Step3";
 import Result from "./pages/Simulation/Result";
+import ForgotPassword from "./pages/Login/ForgotPassword";
+import Signup from "./pages/Login/Signup";
+import ChangePassword from "./pages/Login/ChangePassword";
+import DeleteAccount from "./pages/Login/DeleteAccount";
 
 
 
@@ -26,6 +30,10 @@ function App() {
         <Route path="/history" element={<History />} />
         <Route path="/glossary" element={<Glossary />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/forgotPassword" element={<ForgotPassword />} />
+        <Route path="/signup" element={<Signup />} />
+        <Route path="/changePassword" element={<ChangePassword />} />
+        <Route path="/deleteAccount" element={<DeleteAccount />} />
         <Route path="/simulation/step1" element={<Step1 />} />
         <Route path="/simulation/step2" element={<Step2 />} />
         <Route path="/simulation/step3" element={<Step3 />} />

--- a/FE/src/pages/History/History.css
+++ b/FE/src/pages/History/History.css
@@ -1,0 +1,257 @@
+/* ===== 공통 래퍼 ===== */
+.hd {
+    --hd-font: 13px;
+    --hd-height: 36px;
+
+    /* 파이차트/결과 텍스트 공통 색 변수(따뜻한 계열) */
+    --color-correct: #fbc02d;
+    /* 머스터드 옐로우 */
+    --color-wrong: #f57c00;
+    /* 웜 오렌지 */
+    --color-unsolved: #b0bec5;
+    /* 차분한 그레이 */
+}
+
+/* ===== 페이지 레이아웃 ===== */
+.hd-page {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 24px 16px;
+}
+
+.hd-title {
+    font-size: 28px;
+    font-weight: 700;
+    margin: 0 0 16px;
+}
+
+.hd-main {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+    .hd-main {
+        grid-template-columns: 7fr 5fr;
+    }
+}
+
+/* ===== 카드 ===== */
+.hd-card {
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    background: #fff;
+    overflow: hidden;
+}
+
+.hd-card-header {
+    padding: 10px 12px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid #f1f5f9;
+    font-weight: 600;
+}
+
+.hd-card-body {
+    padding: 12px;
+}
+
+.hd-small {
+    font-size: 12px;
+    color: #64748b;
+}
+
+/* ===== 필터 영역 ===== */
+.hd .hd-filters {
+    display: grid;
+    gap: 8px;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    align-items: end;
+    margin-bottom: 12px;
+}
+
+.hd .hd-label {
+    font-size: 11px;
+    color: #475569;
+    margin-bottom: 4px;
+}
+
+.hd .hd-filters input[type="date"],
+.hd .hd-filters input[type="text"],
+.hd .hd-filters input[type="search"],
+.hd .hd-filters select {
+    box-sizing: border-box;
+    width: 100%;
+    height: var(--hd-height);
+    padding: 0 8px;
+    font-size: var(--hd-font);
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    background: #fff;
+}
+
+/* ===== 툴바 ===== */
+.hd .hd-toolbar {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.hd .hd-toolbar select {
+    height: var(--hd-height);
+    width: 100px;
+    /* 동일 폭 */
+    font-size: var(--hd-font);
+    padding: 0 8px;
+    border: 1px solid #e5e7eb;
+    border-radius: 6px;
+    background: #fff;
+    box-sizing: border-box;
+}
+
+/* ===== 표 ===== */
+.hd-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+}
+
+.hd-table thead {
+    background: #f8fafc;
+}
+
+.hd-table th,
+.hd-table td {
+    padding: 6px 6px;
+    border-bottom: 1px solid #eef2f7;
+    text-align: left;
+}
+
+.hd-table td.right {
+    text-align: right;
+}
+
+/* ===== 페이지네이션 ===== */
+.hd-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.hd-muted {
+    color: #64748b;
+    font-size: 13px;
+}
+
+.hd .hd-pagination .hd-btn,
+.hd .hd-pagination button {
+    height: var(--hd-height);
+    width: 70px;
+    /* 네 버튼 동일 폭 */
+    font-size: var(--hd-font);
+    padding: 0px 12px;
+    border: 1px solid #e2e8f0;
+    border-radius: 6px;
+    background: #fff;
+    cursor: pointer;
+}
+
+.hd .hd-pagination .hd-btn:disabled,
+.hd .hd-pagination button:disabled {
+    opacity: 0.5;
+    cursor: default;
+}
+
+/* ===== 오른쪽 카드 묶음 ===== */
+.hd-right {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-top: 24px;
+}
+
+/* ===== 파이차트 카드 (높이 확장) ===== */
+.hd-card.chart-card {
+    min-height: 460px;   /* 기존보다 더 크게 */
+}
+
+.hd-card.chart-card .hd-card-body {
+    padding: 0;
+}
+
+.hd-card.chart-card .chart-wrapper {
+    height: 420px;      /* 실제 차트 영역 높이 */
+}
+
+
+/* 성과 요약 카드 높이 고정 */
+.hd-card.summary-card {
+    min-height: 245px;   /* 원하는 값으로 수정 */
+    display: flex;            /* 카드 자체를 flex 컨테이너 */
+    flex-direction: column;
+}
+
+
+.hd-card.summary-card .hd-card-body {
+    flex: 1;                  /* 남는 공간 차지 */
+    display: flex;
+    align-items: center;      /* 세로 중앙 정렬 */
+    font-size: 16px;          /* 글씨 조금 크게 */
+    line-height: 1.6;         /* 줄간격 넉넉히 */
+}
+
+/* ===== 이력 테이블 스크롤 영역(고정 높이) ===== */
+.hd-table-scroll {
+    height: 550px;
+    /* PC 고정 높이 */
+    overflow-y: auto;
+    border-top: 1px solid #e5e7eb;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+/* 헤더 고정 + 배경 일치 */
+.hd-table thead th {
+    position: sticky;
+    top: 0;
+    background: #f8fafc;
+    /* thead 배경과 동일 */
+    z-index: 1;
+}
+
+/* ===== 스크롤바(차분한 옅은 노랑) ===== */
+.hd-table-scroll::-webkit-scrollbar {
+    width: 8px;
+}
+
+.hd-table-scroll::-webkit-scrollbar-thumb {
+    background-color: #fffde7;
+    border-radius: 4px;
+}
+
+.hd-table-scroll::-webkit-scrollbar-thumb:hover {
+    background-color: #fff9c4;
+}
+
+.hd-table-scroll::-webkit-scrollbar-track {
+    background-color: #ffffff;
+}
+
+/* ===== 결과 색상(텍스트) ===== */
+.hd-result-correct {
+    color: var(--color-correct);
+    font-weight: 600;
+}
+
+.hd-result-wrong {
+    color: var(--color-wrong);
+    font-weight: 600;
+}
+
+.hd-result-unsolved {
+    color: var(--color-unsolved);
+    font-weight: 600;
+}
+
+

--- a/FE/src/pages/History/History.jsx
+++ b/FE/src/pages/History/History.jsx
@@ -1,10 +1,350 @@
-// src/pages/History/History.jsx
-function History() {
-  return (
-    <div>
-      <h1>History Page</h1>
-    </div>
-  );
+// src/pages/HistoryDashboard.jsx
+import { useEffect, useMemo, useState } from "react";
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from "recharts";
+import Navigation from "../../components/Navigation";
+import "../History/History.css";
+
+const RANGE_MIN = "2023-01-01";
+const RANGE_MAX = "2024-12-31";
+const LEGEND_W = 160;
+
+const clampDate = (v) => {
+  if (!v) return v;
+  if (v < RANGE_MIN) return RANGE_MIN;
+  if (v > RANGE_MAX) return RANGE_MAX;
+  return v;
+};
+
+const qs = (obj) =>
+  Object.entries(obj)
+    .filter(([, v]) => v !== undefined && v !== null && v !== "")
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+    .join("&");
+
+const fmt = (n, d = 1) =>
+  new Intl.NumberFormat(undefined, { maximumFractionDigits: d, minimumFractionDigits: d }).format(n);
+
+async function getHistory(filters) {
+  const url = `/api/history?${qs(filters)}`;
+  const res = await fetch(url, { credentials: "include" });
+  if (!res.ok) throw new Error(`history:${res.status}`);
+  return res.json();
+}
+async function getStats(filters) {
+  const url = `/api/history/stats?${qs({ from: filters.from, to: filters.to, type: filters.type })}`;
+  const res = await fetch(url, { credentials: "include" });
+  if (!res.ok) throw new Error(`stats:${res.status}`);
+  return res.json();
+}
+async function getSummary() {
+  const res = await fetch(`/api/history/summary`, { credentials: "include" });
+  if (!res.ok) throw new Error(`summary:${res.status}`);
+  const d = await res.json();
+
+  const buy = await getStats({ from: RANGE_MIN, to: RANGE_MAX, type: "매수", page: 1, size: 1 });
+  const sell = await getStats({ from: RANGE_MIN, to: RANGE_MAX, type: "매도", page: 1, size: 1 });
+
+  const pct = (x) => (isFinite(x) ? x * 100 : 0);
+  const sign = (x) => (x > 0 ? `+${fmt(x, 1)}` : fmt(x, 1));
+
+  const line1 = `누적 정답률: ${fmt(pct(d.accuracy ?? 0), 1)}% (총 ${d.total ?? 0}회)`;
+  const line2 = `매수 정답률 ${fmt(pct(buy.accuracy ?? 0), 0)}% (${buy.total ?? 0}회)`;
+  const line3 = `매도 정답률 ${fmt(pct(sell.accuracy ?? 0), 0)}% (${sell.total ?? 0}회)`;
+  const line4 = `총 손익: ${sign(d.totalPnl ?? 0)} (평균 ${sign(d.avgPnl ?? 0)})`;
+  const line5 = `최대 이익: ${fmt(d.maxPnl ?? 0, 1)}`;
+  const line6 = `최대 손실: ${fmt(d.minPnl ?? 0, 1)}`;
+
+  return { comment: [line1, line2, line3, line4, line5, line6].join("\n") };
 }
 
-export default History;
+const LegendWithPercent = ({ payload }) => {
+  const total = payload.reduce((s, p) => s + (p?.payload?.value ?? 0), 0);
+  return (
+    <ul style={{ listStyle: "none", padding: 0, margin: 0, width: LEGEND_W }}>
+      {payload.map((e, i) => {
+        const v = e?.payload?.value ?? 0;
+        const pct = total ? (v / total) * 100 : 0;
+        return (
+          <li key={i} style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}>
+            <span style={{ width: 14, height: 14, background: e.color }} />
+            <span style={{ fontSize: 14 }}>
+              {e.value} {v} ({fmt(pct, 1)}%)
+            </span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+};
+
+export default function HistoryDashboard() {
+  const [filters, setFilters] = useState({
+    from: RANGE_MIN,
+    to: RANGE_MAX,
+    type: "",
+    sort: "date,desc",
+    page: 1,
+    size: 20,
+  });
+
+  const [list, setList] = useState({ items: [], page: 1, size: 20, total: 0 });
+  const [stats, setStats] = useState({ total: 0, correct: 0, wrong: 0, unsolved: 0, accuracy: 0 });
+  const [summary, setSummary] = useState("");
+  const [summaryLoading, setSummaryLoading] = useState(true);
+
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState("");
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    setErr("");
+
+    const t = setTimeout(async () => {
+      try {
+        const l = await getHistory(filters);
+        if (!alive) return;
+        setList(l);
+
+        const s = await getStats(filters);
+        if (!alive) return;
+        setStats(s);
+      } catch (e) {
+        if (!alive) return;
+        setErr(e?.message || "데이터 불러오기 실패");
+        setStats({ total: 0, correct: 0, wrong: 0, unsolved: 0, accuracy: 0 });
+      } finally {
+        if (alive) setLoading(false);
+      }
+    }, 150);
+
+    return () => {
+      alive = false;
+      clearTimeout(t);
+    };
+  }, [filters.from, filters.to, filters.type, filters.sort, filters.page, filters.size]);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        setSummaryLoading(true);
+        const s = await getSummary();
+        if (!alive) return;
+        setSummary(s.comment || "");
+      } catch {
+        if (!alive) return;
+        setSummary("");
+      } finally {
+        if (alive) setSummaryLoading(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, []);
+
+  const accuracyPct = useMemo(
+    () => (stats.total - stats.unsolved > 0 ? stats.accuracy * 100 : 0),
+    [stats]
+  );
+  const pieData = useMemo(
+    () => [
+      { name: "정답", value: stats.correct, key: "correct" },
+      { name: "오답", value: stats.wrong, key: "wrong" },
+      { name: "미풀이", value: stats.unsolved, key: "unsolved" },
+    ],
+    [stats]
+  );
+
+  const COLOR_VAR = {
+    correct: "var(--color-correct)",
+    wrong: "var(--color-wrong)",
+    unsolved: "var(--color-unsolved)",
+  };
+
+  const setPage = (p) => setFilters((f) => ({ ...f, page: p }));
+  const setSize = (s) => setFilters((f) => ({ ...f, size: s, page: 1 }));
+
+  return (
+    <>
+      <Navigation />
+      <div className="hd hd-page">
+        <h1 className="hd-title">과거 이력</h1>
+
+        <div className="hd-main">
+          {/* Left */}
+          <div>
+            <div className="hd-filters">
+              <div>
+                <label className="hd-label">시작일</label>
+                <input
+                  type="date"
+                  min={RANGE_MIN}
+                  max={RANGE_MAX}
+                  value={filters.from || ""}
+                  onChange={(e) => setFilters((f) => ({ ...f, from: clampDate(e.target.value), page: 1 }))}
+                />
+              </div>
+              <div>
+                <label className="hd-label">종료일</label>
+                <input
+                  type="date"
+                  min={RANGE_MIN}
+                  max={RANGE_MAX}
+                  value={filters.to || ""}
+                  onChange={(e) => setFilters((f) => ({ ...f, to: clampDate(e.target.value), page: 1 }))}
+                />
+              </div>
+              <div>
+                <label className="hd-label">타입</label>
+                <select
+                  value={filters.type || ""}
+                  onChange={(e) => setFilters((f) => ({ ...f, type: e.target.value, page: 1 }))}
+                >
+                  <option value="">전체</option>
+                  <option value="매수">매수</option>
+                  <option value="매도">매도</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="hd-card">
+              <div className="hd-card-header">
+                <div>이력</div>
+                <div className="hd-toolbar">
+                  <select value={filters.size} onChange={(e) => setSize(Number(e.target.value))}>
+                    <option value={10}>10</option>
+                    <option value={20}>20</option>
+                    <option value={50}>50</option>
+                  </select>
+                  <select value={filters.sort} onChange={(e) => setFilters((f) => ({ ...f, sort: e.target.value }))}>
+                    <option value="date,desc">날짜 최신순</option>
+                    <option value="date,asc">날짜 과거순</option>
+                  </select>
+                </div>
+              </div>
+
+              <div className="hd-card-body">
+                <div className="hd-table-scroll">
+                  <table className="hd-table">
+                    <thead>
+                      <tr>
+                        <th>날짜</th>
+                        <th>매수/매도</th>
+                        <th>예측</th>
+                        <th>실제</th>
+                        <th>결과</th>
+                        <th className="right">PnL</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {loading ? (
+                        <tr>
+                          <td colSpan={6} style={{ padding: 24, textAlign: "center", color: "#64748b" }}>
+                            불러오는 중
+                          </td>
+                        </tr>
+                      ) : list.items.length === 0 ? (
+                        <tr>
+                          <td colSpan={6} style={{ padding: 24, textAlign: "center", color: "#64748b" }}>
+                            데이터 없음
+                          </td>
+                        </tr>
+                      ) : (
+                        list.items.map((r) => (
+                          <tr key={r.id}>
+                            <td>{r.date}</td>
+                            <td>{r.type}</td>
+                            <td>{r.answer || "-"}</td>
+                            <td>{r.actual ?? "-"}</td>
+                            <td>
+                              {r.result === "correct" && <span className="hd-result-correct">정답</span>}
+                              {r.result === "wrong" && <span className="hd-result-wrong">오답</span>}
+                              {r.result === "unsolved" && <span className="hd-result-unsolved">미풀이</span>}
+                            </td>
+                            <td className="right">{r.pnl ?? "-"}</td>
+                          </tr>
+                        ))
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+
+                <div className="hd-row hd-pagination" style={{ marginTop: 12 }}>
+                  <div className="hd-muted">
+                    총 {list.total}건 • {list.page}/{Math.max(1, Math.ceil(list.total / list.size))} 페이지
+                  </div>
+                  <div style={{ display: "flex", gap: 8 }}>
+                    <button className="hd-btn" onClick={() => setPage(1)} disabled={list.page <= 1}>처음</button>
+                    <button className="hd-btn" onClick={() => setPage(list.page - 1)} disabled={list.page <= 1}>이전</button>
+                    <button
+                      className="hd-btn"
+                      onClick={() => setPage(list.page + 1)}
+                      disabled={list.page >= Math.ceil(list.total / list.size)}
+                    >다음</button>
+                    <button
+                      className="hd-btn"
+                      onClick={() => setPage(Math.max(1, Math.ceil(list.total / list.size)))}
+                      disabled={list.page >= Math.ceil(list.total / list.size)}
+                    >마지막</button>
+                  </div>
+                </div>
+
+                {err && <div style={{ marginTop: 8, color: "#dc2626", fontSize: 13 }}>{err}</div>}
+              </div>
+            </div>
+          </div>
+
+          {/* Right */}
+          <div className="hd-right">
+            <div className="hd-card chart-card">
+              <div className="hd-card-header">
+                <div>정답/오답/미풀이</div>
+                <span className="hd-small">정확도 {fmt(accuracyPct)}%</span>
+              </div>
+              <div className="hd-card-body">
+                <div className="chart-wrapper">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <PieChart>
+                      <Pie
+                        dataKey="value"
+                        data={pieData}
+                        innerRadius={0}
+                        outerRadius={120}
+                        paddingAngle={3}
+                        label={false}
+                        labelLine={false}
+                        stroke="none"
+                        cx="45%"
+                      >
+                        {pieData.map((entry) => (
+                          <Cell key={`c-${entry.key}`} fill={COLOR_VAR[entry.key]} />
+                        ))}
+                      </Pie>
+                      <Tooltip formatter={(v) => `${v}건`} />
+                      <Legend
+                        layout="vertical"
+                        align="right"
+                        verticalAlign="middle"
+                        wrapperStyle={{ width: LEGEND_W }}
+                        content={<LegendWithPercent />}
+                      />
+                    </PieChart>
+                  </ResponsiveContainer>
+                </div>
+              </div>
+            </div>
+
+            <div className="hd-card summary-card">
+              <div className="hd-card-header">성과 요약</div>
+              <div className="hd-card-body" style={{ display: "flex", alignItems: "center" }}>
+                <div style={{ whiteSpace: "pre-wrap", color: "#334155", fontSize: 16, lineHeight: 1.6 }}>
+                  {summaryLoading ? "분석 중" : summary || "요약 코멘트 없음"}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/FE/src/pages/Login/ChangePassword.jsx
+++ b/FE/src/pages/Login/ChangePassword.jsx
@@ -1,0 +1,113 @@
+// src/pages/ChangePassword.jsx
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Navigation from "../../components/Navigation";
+import "../Login/Login.css";
+
+const PWD_REGEX =
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[ !"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]).{8,}$/;
+
+export default function ChangePassword() {
+  const nav = useNavigate();
+  const [currentPwd, setCurrentPwd] = useState("");
+  const [newPwd, setNewPwd] = useState("");
+  const [confirmPwd, setConfirmPwd] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState("");
+  const [done, setDone] = useState(false);
+
+  const pwdValid = useMemo(() => PWD_REGEX.test(newPwd), [newPwd]);
+  const pwdMatch = useMemo(() => newPwd === confirmPwd, [newPwd, confirmPwd]);
+  const canSubmit = currentPwd && pwdValid && pwdMatch && !loading;
+
+  async function submit(e) {
+    e.preventDefault();
+    setErr("");
+    if (!pwdValid) { setErr("새 비밀번호 규칙을 확인하세요."); return; }
+    if (!pwdMatch) { setErr("새 비밀번호가 일치하지 않습니다."); return; }
+
+    try {
+      setLoading(true);
+      const res = await fetch("http://localhost:8080/api/auth/updatePassword", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ currentPwd, newPwd, confirmPwd }),
+      });
+      if (!res.ok) {
+        let msg = "변경 실패";
+        try { const data = await res.json(); if (data?.message) msg = data.message; } catch {}
+        throw new Error(msg);
+      }
+      setDone(true);
+      setCurrentPwd(""); setNewPwd(""); setConfirmPwd("");
+    } catch (e) {
+      setErr(e.message || "변경 실패");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function logoutAndGoLogin() {
+    try {
+      await fetch("http://localhost:8080/api/auth/logout", {
+        method: "POST",
+        credentials: "include",
+      });
+    } finally {
+      nav("/login", { replace: true });
+    }
+  }
+
+  return (
+    <>
+      <Navigation />
+      <div className="login-wrap">
+        <div className="login-card">
+          <h1 className="title">비밀번호 변경</h1>
+
+          {done ? (
+            <div className="form" style={{ textAlign: "center" }}>
+              비밀번호를 변경했습니다. 보안을 위해 다시 로그인하세요.
+              <button className="btn" style={{ marginTop: 16 }} onClick={logoutAndGoLogin}>
+                로그아웃 후 로그인
+              </button>
+            </div>
+          ) : (
+            <form className="form" onSubmit={submit}>
+              <label className="label" htmlFor="cur">현재 비밀번호</label>
+              <input
+                id="cur" type="password" className="input" value={currentPwd}
+                onChange={(e)=>setCurrentPwd(e.target.value)} required
+              />
+
+              <label className="label" htmlFor="new">새 비밀번호</label>
+              <input
+                id="new" type="password" className="input" value={newPwd}
+                onChange={(e)=>setNewPwd(e.target.value)} required aria-describedby="pwd-help"
+              />
+              <div id="pwd-help" className={`hint ${pwdValid ? "success" : ""}`}>
+                최소 8자, 대/소문자·숫자·특수문자 각 1개 이상
+              </div>
+
+              <label className="label" htmlFor="cnf">새 비밀번호 확인</label>
+              <input
+                id="cnf" type="password" className="input" value={confirmPwd}
+                onChange={(e)=>setConfirmPwd(e.target.value)} required
+              />
+              <div className={`hint ${confirmPwd ? (pwdMatch ? "success" : "error") : ""}`}>
+                {confirmPwd ? (pwdMatch ? "일치합니다." : "일치하지 않습니다.") : "\u00A0"}
+              </div>
+
+              {err && <div className="error">{err}</div>}
+
+              <button className="btn" disabled={!canSubmit}>
+                {loading ? "변경 중..." : "비밀번호 변경"}
+              </button>
+            </form>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/FE/src/pages/Login/DeleteAccount.jsx
+++ b/FE/src/pages/Login/DeleteAccount.jsx
@@ -1,0 +1,96 @@
+// src/pages/DeleteAccount.jsx
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Navigation from "../../components/Navigation";
+import "../Login/Login.css";
+
+export default function DeleteAccount() {
+  const nav = useNavigate();
+  const [password, setPassword] = useState("");
+  const [agree, setAgree] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState("");
+  const [done, setDone] = useState(false);
+
+  const canSubmit = Boolean(password) && agree && !loading;
+
+  async function submit(e) {
+    e.preventDefault();
+    setErr("");
+    try {
+      setLoading(true);
+      const res = await fetch("http://localhost:8080/api/auth/deleteAccount", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ password }),
+      });
+      if (!res.ok) throw new Error("탈퇴 실패");
+      setDone(true);
+    } catch (e) {
+      setErr(e.message || "탈퇴 실패");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <Navigation />
+      <div className="login-wrap">
+        <div className="login-card">
+          <h1 className="title">회원 탈퇴</h1>
+
+          {done ? (
+            <div className="form" style={{ textAlign: "center" }}>
+              계정이 비활성화되었습니다. 30일 후 영구 삭제됩니다.
+              <button className="btn" style={{ marginTop: 16 }} onClick={() => nav("/login")}>
+                로그인 페이지로 이동
+              </button>
+            </div>
+          ) : (
+            <form className="form" onSubmit={submit}>
+              {/* 안내 박스 */}
+              <div className="hint" style={{ border: "1px solid #e5e7eb", padding: 12, borderRadius: 8 }}>
+                <strong>안내</strong>
+                <ul style={{ marginTop: 8, paddingLeft: 18 }}>
+                  <li>탈퇴 후 30일 동안은 로그인할 수 없으며, 이후 계정은 영구 삭제됩니다.</li>
+                  <li>시뮬레이션 이력 등 이용 기록은 삭제됩니다.</li>
+                  <li>삭제 이후 복구는 불가능합니다.</li>
+                </ul>
+              </div>
+
+              {/* 동의 체크 */}
+              <label className="remember" style={{ marginTop: 12 }}>
+                <input
+                  type="checkbox"
+                  checked={agree}
+                  onChange={(e) => setAgree(e.target.checked)}
+                />
+                위 내용을 확인했으며 계정 삭제에 동의합니다.
+              </label>
+
+              {/* 비밀번호 */}
+              <label className="label" htmlFor="pwd" style={{ marginTop: 8 }}>현재 비밀번호</label>
+              <input
+                id="pwd"
+                type="password"
+                className="input"
+                placeholder="비밀번호를 입력하세요"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+              />
+
+              {err && <div className="error">{err}</div>}
+
+              <button className="btn" disabled={!canSubmit}>
+                {loading ? "처리 중..." : "회원 탈퇴"}
+              </button>
+            </form>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/FE/src/pages/Login/ForgotPassword.jsx
+++ b/FE/src/pages/Login/ForgotPassword.jsx
@@ -1,0 +1,71 @@
+// src/pages/ForgotPassword.jsx
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import Navigation from "../../components/Navigation";     // <- 경로 확인 필요
+import "../Login/Login.css";                           // <- 프로젝트에 맞게 유지
+
+export default function ForgotPassword() {
+  const [memberId, setMemberId] = useState("");
+  const [memberEmail, setEmail] = useState("");
+  const [done, setDone] = useState(false);
+  const [err, setErr] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function submit(e) {
+    e.preventDefault();
+    setErr(""); setLoading(true);
+    try {
+      const res = await fetch("http://localhost:8080/api/auth/forgotPassword", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ memberId, memberEmail }),
+      });
+      if (res.ok) setDone(true);
+      else setErr("요청을 처리할 수 없습니다.");
+    } catch {
+      setErr("네트워크 오류");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <Navigation />
+      <div className="login-wrap">
+        <div className="login-card">
+          <h1 className="title">비밀번호 찾기</h1>
+
+          {done ? (
+            <p>임시 비밀번호를 이메일로 보냈습니다. 로그인 후 비밀번호를 변경하세요.</p>
+          ) : (
+            <form className="form" onSubmit={submit}>
+              <label className="label" htmlFor="fid">아이디</label>
+              <input
+                id="fid" className="input" placeholder="아이디"
+                value={memberId} onChange={(e)=>setMemberId(e.target.value)}
+                autoComplete="username" required
+              />
+
+              <label className="label" htmlFor="fem">이메일</label>
+              <input
+                id="fem" type="email" className="input" placeholder="이메일"
+                value={memberEmail} onChange={(e)=>setEmail(e.target.value)} required
+              />
+
+              {err && <div className="error">{err}</div>}
+
+              <button type="submit" className="btn" disabled={loading}>
+                {loading ? "전송 중..." : "임시 비밀번호 발송"}
+              </button>
+            </form>
+          )}
+
+          <div className="login-footer">
+            <Link className="link" to="/login">로그인으로 돌아가기</Link>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/FE/src/pages/Login/Login.css
+++ b/FE/src/pages/Login/Login.css
@@ -1,91 +1,163 @@
-/* 전체 배경 (라이트그레이) */
-.login-container {
+.login-wrap {
+  min-height: calc(100vh - 70px);
   display: flex;
-  align-items: center;
   justify-content: center;
-  height: 100vh;
-  background-color: #f5f6f8; /* 라이트그레이 */
+  /* center → flex-start 로 바꾸고 위 여백 추가 */
+  align-items: center;
+  padding-top: 70px;
+  /* 원하는 만큼 조절: 100~200px */
+  background: #f5f7fb;
 }
 
-/* 중앙 카드 */
-.login-box {
-  background: #fff; /* 화이트 카드 */
-  padding: 40px;
-  border-radius: 12px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
-  width: 100%;
-  max-width: 400px;
+.login-card {
+  width: 380px;
+  /* 카드 폭을 줄여서 아담하게 */
+  max-width: 380px;
+  min-width: 380px;
+  border-radius: 16px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, .08);
+  padding: 28px 24px;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.title {
+  margin: 0 0 18px;
   text-align: center;
-}
-
-/* 타이틀 */
-.login-title {
-  margin-bottom: 8px;
-  font-size: 24px;
-  font-weight: bold;
+  font-size: 20px;
+  font-weight: 700;
   color: #222;
 }
 
-/* 부제 */
-.login-subtitle {
-  margin-bottom: 24px;
-  font-size: 14px;
-  color: #666;
+.form {
+  display: grid;
+  gap: 10px;
 }
 
-/* 입력 폼 */
-.login-form {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.login-form input {
-  padding: 12px;
-  font-size: 16px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  outline: none;
-}
-
-.login-form input:focus {
-  border-color: #1e90ff;
-  box-shadow: 0 0 4px rgba(30, 144, 255, 0.3);
-}
-
-/* 로그인 버튼 (진한 네이비) */
-/* 로그인 버튼 (세련된 블루 네이비) */
-.login-btn {
-  padding: 12px;
-  background-color: #2F5DCC; /* 세련된 블루네이비 */
-  color: white;
-  font-size: 16px;
-  font-weight: 500;
-  border: none;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: background-color 0.25s;
-}
-
-.login-btn:hover {
-  background-color: #2448A6; /* 조금 더 진한 블루 */
-}
-
-
-
-/* 회원가입 버튼 (화이트+테두리) */
-.signup-btn {
-  padding: 12px;
-  background-color: #fff;
+.label {
+  font-size: 13px;
   color: #333;
-  font-size: 16px;
-  border: 1px solid #ccc;
-  border-radius: 6px;
-  cursor: pointer;
-  transition: all 0.25s;
+  font-weight: 500;
 }
 
-.signup-btn:hover {
-  border-color: #1e90ff;
-  color: #1e90ff;
+.input {
+  width: 100%;
+  height: 44px;
+  /* 버튼과 동일 */
+  padding: 0 12px;
+  border: 1px solid #e3e6ee;
+  border-radius: 10px;
+  background: #fbfcff;
+  font-size: 14px;
+  outline: none;
+  box-sizing: border-box;
+  /* 버튼과 동일 계산 */
+  display: block;
+}
+
+.input:focus {
+  border-color: #cfd6ee;
+  background: #fff;
+}
+
+.remember {
+  margin-top: 2px;
+  font-size: 13px;
+  color: #444;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.error {
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: #fff2f2;
+  color: #c62828;
+  border: 1px solid #ffd6d6;
+  font-size: 13px;
+}
+
+.btn {
+  width: 100%;
+  height: 44px;
+  /* 인풋과 동일 */
+  border: 0;
+  border-radius: 10px;
+  /* 인풋과 맞춤 */
+  font-weight: 700;
+  background: #2f66f5;
+  color: #fff;
+  cursor: pointer;
+  font-size: 15px;
+  box-sizing: border-box;
+  display: block;
+}
+
+.btn:disabled {
+  opacity: .6;
+  cursor: not-allowed;
+}
+
+.login-footer {
+  text-align: center;
+  margin-top: 12px;
+  color: #666;
+  font-size: 14px;
+}
+
+.login-footer .dot {
+  margin: 0 8px;
+  color: #c3c7d4;
+}
+
+.link {
+  color: #2f66f5;
+  text-decoration: none;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+/* 로그인과 비번찾기 카드 폭 고정 */
+.auth-card,
+.login-card {
+  width: 380px;
+  max-width: 380px;
+  min-width: 380px;
+}
+
+/* 카드 안 폼은 항상 좌측 정렬 */
+.auth-card .form {
+  text-align: left;
+}
+
+.auth-card .label {
+  text-align: left;
+  display: block;
+  margin-bottom: 1px;
+}
+
+/* 인풋·버튼 크기 통일(이미 있다면 유지) */
+.auth-card .input,
+.auth-card .btn {
+  width: 100%;
+  height: 44px;
+  box-sizing: border-box;
+}
+
+/* login.css 하단 */
+.hint {
+  font-size: 12px;
+  color: #64748b;
+  margin-top: -4px
+}
+
+.hint.success {
+  color: #16a34a
+}
+
+.hint.error {
+  color: #dc2626
 }

--- a/FE/src/pages/Login/Login.jsx
+++ b/FE/src/pages/Login/Login.jsx
@@ -1,50 +1,92 @@
-// Login.jsx
-import { useState } from "react";
+// src/pages/Login.jsx
+import { useState, useEffect } from "react";
 import axios from "axios";
-import "./Login.css";
+import Navigation from "../../components/Navigation";
+import "../Login/Login.css";
 
-function Login() {
-  const [userId, setUserId] = useState("");
-  const [password, setPassword] = useState("");
+export default function Login() {
+  const [memberId, setMemberId] = useState("");
+  const [memberPwd, setMemberPwd] = useState("");
+  const [remember, setRemember] = useState(false);
+  const [err, setErr] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const saved = localStorage.getItem("saved_memberId");
+    if (saved) { setMemberId(saved); setRemember(true); }
+  }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    setErr(""); setLoading(true);
     try {
-      const res = await axios.post("http://localhost:8080/api/login", {
-        memberId: userId,
-        memberPwd: password,
-      });
-      alert(res.data); // "로그인 성공" or "로그인 실패"
-    } catch (err) {
-      console.error("로그인 에러:", err.response?.data || err.message);
-    }
+      await axios.post(
+        "http://localhost:8080/api/auth/login",
+        { memberId, memberPwd },
+        { withCredentials: true }
+      );
+      if (remember) localStorage.setItem("saved_memberId", memberId);
+      else localStorage.removeItem("saved_memberId");
+      window.location.href = "/";
+    } catch {
+      setErr("아이디 또는 비밀번호가 올바르지 않습니다.");
+    } finally { setLoading(false); }
   };
 
-
   return (
-    <div className="login-container">
-      <div className="login-box">
-        <h1 className="login-title">로그인</h1>
-        <form className="login-form" onSubmit={handleSubmit}>
-          <input
-            type="text"
-            placeholder="아이디"
-            value={userId}
-            onChange={(e) => setUserId(e.target.value)}
-          />
-          <input
-            type="password"
-            placeholder="비밀번호"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-          />
-          <button type="submit" className="login-btn">
-            로그인
-          </button>
-        </form>
+    <>
+      <Navigation />
+      <div className="login-wrap">
+        <div className="login-card">
+          <h1 className="title">로그인</h1>
+          <form className="form" onSubmit={handleSubmit}>
+            <label className="label" htmlFor="memberId">아이디</label>
+            <input
+              id="memberId"
+              type="text"
+              className="input"
+              placeholder="아이디"
+              value={memberId}
+              onChange={(e)=>setMemberId(e.target.value)}
+              autoComplete="username"
+              required
+            />
+
+            <label className="label" htmlFor="memberPwd">비밀번호</label>
+            <input
+              id="memberPwd"
+              type="password"
+              className="input"
+              placeholder="비밀번호"
+              value={memberPwd}
+              onChange={(e)=>setMemberPwd(e.target.value)}
+              autoComplete="current-password"
+              required
+            />
+
+            <label className="remember">
+              <input
+                type="checkbox"
+                checked={remember}
+                onChange={(e)=>setRemember(e.target.checked)}
+              />
+              아이디 저장
+            </label>
+
+            {err && <div className="error">{err}</div>}
+
+            <button type="submit" className="btn" disabled={loading}>
+              {loading ? "로그인 중..." : "로그인"}
+            </button>
+          </form>
+
+          <div className="login-footer">
+            <a className="link" href="/signup">회원가입</a>
+            <span className="dot">·</span>
+            <a className="link" href="/forgotPassword">비밀번호 찾기</a>
+          </div>
+        </div>
       </div>
-    </div>
+    </>
   );
 }
-
-export default Login;

--- a/FE/src/pages/Login/Signup.jsx
+++ b/FE/src/pages/Login/Signup.jsx
@@ -1,0 +1,352 @@
+// src/pages/Signup.jsx
+import { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import Navigation from "../../components/Navigation";
+import "../Login/Login.css";
+
+const PWD_REGEX =
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[ !"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]).{8,}$/;
+
+export default function Signup() {
+  const nav = useNavigate();
+  const [form, setForm] = useState({
+    memberId: "",
+    memberEmail: "",
+    memberName: "",
+    memberPwd: "",
+    confirmPwd: "",
+  });
+
+  const [idChecking, setIdChecking] = useState(false);
+  const [idExists, setIdExists] = useState(null); // 0 | 1 | null
+  const [idMsg, setIdMsg] = useState("");
+
+  const [emailChecking, setEmailChecking] = useState(false);
+  const [emailExists, setEmailExists] = useState(null); // 0 | 1 | null
+  const [emailMsg, setEmailMsg] = useState("");
+
+  const [emailSending, setEmailSending] = useState(false);
+  const [emailSendMsg, setEmailSendMsg] = useState("");
+  const [emailCode, setEmailCode] = useState("");
+  const [emailVerifying, setEmailVerifying] = useState(false);
+  const [emailVerifyMsg, setEmailVerifyMsg] = useState("");
+  const [emailVerified, setEmailVerified] = useState(false);
+  const [emailVerifyError, setEmailVerifyError] = useState(false);
+
+  const [codeRequested, setCodeRequested] = useState(false);
+  const [timer, setTimer] = useState(0);
+
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState("");
+
+  const idRuleError =
+    form.memberId.trim().length > 0 && !/^[A-Za-z0-9]+$/.test(form.memberId);
+
+  const onChange = (e) => {
+    const { name, value } = e.target;
+    setForm((s) => ({ ...s, [name]: value }));
+
+    if (name === "memberId") {
+      setIdExists(null);
+      setIdChecking(false);
+      setIdMsg(idRuleError ? "영문과 숫자만 입력하세요." : "");
+    }
+    if (name === "memberEmail") {
+      setEmailVerified(false);
+      setEmailVerifyError(false);
+      setEmailCode("");
+      setEmailVerifyMsg("");
+      setEmailSendMsg("");
+      setCodeRequested(false);
+      setTimer(0);
+      setEmailExists(null);
+      setEmailMsg("");
+    }
+  };
+
+  const pwdValid = useMemo(() => PWD_REGEX.test(form.memberPwd), [form.memberPwd]);
+  const pwdMatch = useMemo(
+    () => form.memberPwd === form.confirmPwd,
+    [form.memberPwd, form.confirmPwd]
+  );
+
+  // 아이디 중복 체크(디바운스)
+  useEffect(() => {
+    const id = form.memberId.trim();
+    if (!id || idRuleError) {
+      if (idRuleError) setIdMsg("영문과 숫자만 입력하세요.");
+      return;
+    }
+    const t = setTimeout(async () => {
+      try {
+        setIdChecking(true);
+        const res = await fetch(
+          `http://localhost:8080/api/auth/check-id?memberId=${encodeURIComponent(id)}`,
+          { credentials: "include" }
+        );
+        if (!res.ok) throw new Error();
+        const raw = await res.json();
+        const exists = raw && typeof raw === "object" && "exists" in raw ? Number(raw.exists) : Number(raw);
+        const v = exists === 1 ? 1 : 0;
+        setIdExists(v);
+        setIdMsg(v === 0 ? "사용 가능한 아이디입니다." : "이미 사용 중인 아이디입니다.");
+      } catch {
+        setIdExists(null);
+        setIdMsg("중복 체크 실패");
+      } finally {
+        setIdChecking(false);
+      }
+    }, 400);
+    return () => clearTimeout(t);
+  }, [form.memberId, idRuleError]);
+
+  // 타이머
+  useEffect(() => {
+    if (timer <= 0) return;
+    const iv = setInterval(() => setTimer((s) => s - 1), 1000);
+    return () => clearInterval(iv);
+  }, [timer]);
+
+  const mmss = (sec) => {
+    const m = Math.floor(sec / 60);
+    const s = sec % 60;
+    return `${String(m).padStart(1, "0")}:${String(s).padStart(2, "0")}`;
+  };
+
+  // 이메일 코드 전송
+  const sendCode = async () => {
+    const email = form.memberEmail.trim();
+    setEmailSendMsg("");
+    setEmailVerifyMsg("");
+    setEmailVerifyError(false);
+    setEmailMsg("");
+    setEmailExists(null);
+    if (!email) { setEmailSendMsg("이메일을 입력하세요."); return; }
+
+    try {
+      setEmailChecking(true);
+      const chk = await fetch(
+        `http://localhost:8080/api/auth/check-email?memberEmail=${encodeURIComponent(email)}`,
+        { credentials: "include" }
+      );
+      if (!chk.ok) throw new Error();
+      const raw = await chk.json();
+      const exists = raw && typeof raw === "object" && "exists" in raw ? Number(raw.exists) : Number(raw);
+      if (exists === 1) {
+        setEmailExists(1);
+        setEmailMsg("이미 사용 중인 이메일입니다.");
+        return;
+      }
+      setEmailExists(0);
+      setEmailMsg("사용 가능한 이메일입니다.");
+    } catch {
+      setEmailExists(null);
+      setEmailMsg("이메일 중복 체크 실패");
+      return;
+    } finally {
+      setEmailChecking(false);
+    }
+
+    try {
+      setEmailSending(true);
+      const res = await fetch("http://localhost:8080/api/auth/email/send", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ email }),
+      });
+      if (!res.ok) throw new Error();
+      setEmailSendMsg("인증코드를 전송했습니다. 3분 이내 입력하세요.");
+      setCodeRequested(true);
+      setTimer(180);
+      setEmailVerified(false);
+    } catch {
+      setEmailSendMsg("전송 실패. 잠시 후 다시 시도하세요.");
+    } finally {
+      setEmailSending(false);
+    }
+  };
+
+  // 이메일 코드 확인
+  const verifyCode = async () => {
+    const email = form.memberEmail.trim();
+    const code = emailCode.trim();
+    setEmailVerifyMsg("");
+    setEmailVerifyError(false);
+    if (!email) { setEmailVerifyMsg("이메일을 입력하세요."); return; }
+    if (!code) { setEmailVerifyMsg("인증코드를 입력하세요."); return; }
+    if (timer <= 0) { setEmailVerifyMsg("인증코드가 만료되었습니다. 재전송하세요."); return; }
+
+    try {
+      setEmailVerifying(true);
+      const res = await fetch("http://localhost:8080/api/auth/email/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ email, code }),
+      });
+      if (!res.ok) {
+        setEmailVerified(false);
+        setEmailVerifyError(true);
+        setEmailVerifyMsg("인증 코드가 틀렸습니다. 다시 확인해주세요.");
+        return;
+      }
+      setEmailVerified(true);
+      setEmailVerifyError(false);
+      setEmailVerifyMsg("이메일 인증이 완료되었습니다.");
+    } catch {
+      setEmailVerified(false);
+      setEmailVerifyError(true);
+      setEmailVerifyMsg("인증 코드가 틀렸습니다. 다시 확인해주세요.");
+    } finally {
+      setEmailVerifying(false);
+    }
+  };
+
+  // 제출
+  const submit = async (e) => {
+    e.preventDefault();
+    setErr("");
+    if (!pwdValid) { setErr("비밀번호 규칙을 확인하세요."); return; }
+    if (!pwdMatch) { setErr("비밀번호가 일치하지 않습니다."); return; }
+    if (idExists === 1) { setErr("이미 사용 중인 아이디입니다."); return; }
+    if (!emailVerified) { setErr("이메일 인증을 완료하세요."); return; }
+
+    try {
+      setLoading(true);
+      const res = await fetch("http://localhost:8080/api/auth/join", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({
+          memberId: form.memberId.trim(),
+          memberEmail: form.memberEmail.trim(),
+          memberName: form.memberName.trim(),
+          memberPwd: form.memberPwd,
+        }),
+      });
+      if (!res.ok) throw new Error();
+      nav("/login");
+    } catch {
+      setErr("회원가입 실패");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const allFilled =
+    form.memberId.trim() &&
+    form.memberEmail.trim() &&
+    form.memberName.trim() &&
+    form.memberPwd &&
+    form.confirmPwd;
+
+  const canSubmit =
+    Boolean(allFilled) &&
+    !idRuleError &&
+    idExists === 0 &&
+    pwdValid &&
+    pwdMatch &&
+    !idChecking &&
+    !emailChecking &&
+    emailVerified;
+
+  const canResend = timer <= 0 && !emailSending;
+
+  return (
+    <>
+      <Navigation />
+      <div className="login-wrap">
+        <div className="login-card">
+          <h1 className="title">회원가입</h1>
+
+          <form className="form" onSubmit={submit}>
+            {/* 아이디 */}
+            <label className="label" htmlFor="memberId">아이디</label>
+            <input
+              id="memberId" name="memberId" className="input" placeholder="아이디"
+              value={form.memberId} onChange={onChange} autoComplete="username" required
+            />
+            <div className={`hint ${idRuleError ? "error" : idExists === 0 ? "success" : idExists === 1 ? "error" : ""}`}>
+              {idRuleError ? "영문과 숫자만 입력하세요." : idChecking ? "\u00A0" : idMsg || "\u00A0"}
+            </div>
+
+            {/* 이메일 + 전송 */}
+            <label className="label" htmlFor="memberEmail">이메일</label>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr auto", gap: 8 }}>
+              <input
+                id="memberEmail" name="memberEmail" type="email" className="input" placeholder="이메일"
+                value={form.memberEmail} onChange={onChange} required disabled={emailVerified}
+              />
+              <button
+                type="button" className="btn" onClick={sendCode}
+                disabled={!form.memberEmail.trim() || !canResend || emailVerified || emailChecking}
+              >
+                {emailSending ? "전송중" : timer > 0 ? mmss(timer) : "코드 전송"}
+              </button>
+            </div>
+            <div className={`hint ${emailExists === 1 ? "error" : emailVerified || emailExists === 0 ? "success" : ""}`}>
+              {emailMsg || (emailVerified ? "이메일 인증 완료" : emailSendMsg || "\u00A0")}
+            </div>
+
+            {/* 인증코드 + 확인 */}
+            <label className="label" htmlFor="emailCode">인증코드</label>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr auto", gap: 8 }}>
+              <input
+                id="emailCode" className="input" placeholder="6자리 코드"
+                value={emailCode} onChange={(e) => setEmailCode(e.target.value)}
+                disabled={emailVerified || timer <= 0} inputMode="numeric" pattern="\d*"
+              />
+              <button
+                type="button" className="btn" onClick={verifyCode}
+                disabled={emailVerified || emailVerifying || !emailCode.trim() || timer <= 0}
+              >
+                {emailVerifying ? "확인중" : "확인"}
+              </button>
+            </div>
+            <div className={`hint ${emailVerified ? "success" : emailVerifyError || (codeRequested && timer <= 0) ? "error" : ""}`}>
+              {emailVerifyMsg || (codeRequested && timer <= 0 && !emailVerified ? "코드 만료. 재전송하세요." : "\u00A0")}
+            </div>
+
+            {/* 이름 */}
+            <label className="label" htmlFor="memberName">이름</label>
+            <input
+              id="memberName" name="memberName" className="input" placeholder="이름"
+              value={form.memberName} onChange={onChange} required
+            />
+
+            {/* 비밀번호 */}
+            <label className="label" htmlFor="memberPwd">비밀번호</label>
+            <input
+              id="memberPwd" name="memberPwd" type="password" className="input" placeholder="비밀번호"
+              value={form.memberPwd} onChange={onChange} required aria-describedby="pwd-help"
+            />
+            <div id="pwd-help" className={`hint ${pwdValid ? "success" : ""}`}>
+              최소 8자, 대/소문자·숫자·특수문자 각 1개 이상
+            </div>
+
+            {/* 확인 */}
+            <label className="label" htmlFor="confirmPwd">비밀번호 확인</label>
+            <input
+              id="confirmPwd" name="confirmPwd" type="password" className="input" placeholder="비밀번호 확인"
+              value={form.confirmPwd} onChange={onChange} required
+            />
+            <div className={`hint ${form.confirmPwd ? (pwdMatch ? "success" : "error") : ""}`}>
+              {form.confirmPwd ? (pwdMatch ? "비밀번호가 일치합니다." : "비밀번호가 일치하지 않습니다.") : "\u00A0"}
+            </div>
+
+            {err && <div className="error">{err}</div>}
+
+            <button className="btn" disabled={loading || !canSubmit}>
+              {loading ? "가입 중..." : "회원가입"}
+            </button>
+          </form>
+
+          <div className="login-footer">
+            이미 계정이 있나요? <Link className="link" to="/login">로그인</Link>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## 관련 이슈
Closes #6

## 변경 사항
- 로그인 페이지 UI 수정
- 회원가입 페이지 UI 추가
- 비밀번호 찾기 / 변경 페이지 추가
- 회원탈퇴 페이지 추가
- 과거 이력 대시보드 페이지 JSX로 변환 및 경로 연결
- App.jsx에 각 페이지 라우팅 경로 추가

## 리뷰어에게
- UI 스타일이 기존 Navigation 및 Login.css와 어울리도록 수정했습니다.  
- 경로는 `/api/auth/...` 구조에 맞춰 호출하도록 작성했습니다. 확인 부탁드립니다.
