### PR TITLE
feat14(auth): 로그인 유지 및 네비게이션 드롭다운, 회원가입/이메일, App.jsx 구조 개선

### DIFF
--- a/BE/build.gradle
+++ b/BE/build.gradle
@@ -29,6 +29,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'   // 추가
+	implementation 'org.springframework.boot:spring-boot-starter-mail'       // 추가
+
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/BE/db/schema.sql
+++ b/BE/db/schema.sql
@@ -208,3 +208,15 @@ CREATE  OR REPLACE ALGORITHM=UNDEFINED DEFINER=`goldSys`@`localhost` SQL SECURIT
 SET SQL_MODE=@OLD_SQL_MODE;
 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;
+
+-- -----------------------------------------------------
+-- 보유자산 테이블 추가
+-- -----------------------------------------------------
+CREATE TABLE member_asset (
+    asset_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    member_no BIGINT NOT NULL,
+    balance BIGINT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_asset_member FOREIGN KEY (member_no) REFERENCES members(member_no)
+);

--- a/BE/src/main/java/com/goldSys/BE/config/WebConfig.java
+++ b/BE/src/main/java/com/goldSys/BE/config/WebConfig.java
@@ -9,7 +9,7 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry r) {
         r.addMapping("/api/**")
-                .allowedOrigins("http://localhost:5173")
+                .allowedOrigins("http://localhost:5173", "http://127.0.0.1:5173")
                 .allowedMethods("GET","POST","PUT","DELETE","PATCH","OPTIONS")
                 .allowCredentials(true);
     }

--- a/BE/src/main/java/com/goldSys/BE/member/controller/EmailAuthController.java
+++ b/BE/src/main/java/com/goldSys/BE/member/controller/EmailAuthController.java
@@ -1,0 +1,32 @@
+// src/main/java/com/shinhan/backend/member/controller/EmailAuthController.java
+package com.goldSys.BE.member.controller;
+
+import com.goldSys.BE.member.dto.SendEmailCodeRequestDto;
+import com.goldSys.BE.member.dto.VerifyEmailCodeRequestDto;
+import com.goldSys.BE.member.service.EmailVerificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth/email")
+@RequiredArgsConstructor
+public class EmailAuthController {
+    private final EmailVerificationService svc;
+
+    @PostMapping("/send")
+    public ResponseEntity<Map<String, Boolean>> send(@RequestBody SendEmailCodeRequestDto req){
+        svc.sendCode(req.getMemberEmail());
+        return ResponseEntity.ok(Map.of("ok", true)); // 프런트가 JSON 파싱
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<Map<String, Boolean>> verify(@RequestBody VerifyEmailCodeRequestDto req){
+        boolean ok = svc.verifyCode(req.getMemberEmail(), req.getCode());
+        return ok
+                ? ResponseEntity.ok(Map.of("ok", true))
+                : ResponseEntity.badRequest().body(Map.of("ok", false));
+    }
+}

--- a/BE/src/main/java/com/goldSys/BE/member/controller/MemberController.java
+++ b/BE/src/main/java/com/goldSys/BE/member/controller/MemberController.java
@@ -1,16 +1,13 @@
 package com.goldSys.BE.member.controller;
 
-import com.goldSys.BE.member.dto.LoginRequestDto;
-import com.goldSys.BE.member.dto.LoginResponseDto;
+import com.goldSys.BE.member.dto.*;
 import com.goldSys.BE.member.service.MemberService;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -22,6 +19,8 @@ public class MemberController {
 
     private final MemberService memberService;
 
+
+    // 로그인
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDto> login(@Valid @RequestBody LoginRequestDto req, HttpSession session) {
         LoginResponseDto dto = memberService.login(req);
@@ -31,10 +30,42 @@ public class MemberController {
         return ResponseEntity.ok(dto);
     }
 
+    // 로그아웃
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(HttpSession session) {
         var s = session.getAttribute(LOGIN_ID);
         if (s != null) session.invalidate();
         return ResponseEntity.ok().build();
     }
+
+    // 아이디 중복체크
+    @GetMapping("/check-id")
+    public ResponseEntity<ExistsResponseDto> checkId(@RequestParam String memberId) {
+        return ResponseEntity.ok(ExistsResponseDto.of(memberService.checkId(memberId)));
+    }
+
+    // 이메일 중복체크
+    @GetMapping("/check-email")
+    public ResponseEntity<ExistsResponseDto> checkEmail(@RequestParam String memberEmail) {
+        return ResponseEntity.ok(ExistsResponseDto.of(memberService.checkEmail(memberEmail)));
+    }
+
+    // 회원가입
+    @PostMapping("/join")
+    public ResponseEntity<SignupResponseDto> join(@RequestBody SignupRequestDto req) {
+        SignupResponseDto dto = memberService.join(req, "ROLE_USER");
+        return ResponseEntity.ok(dto);
+    }
+
+    // 로그인 계속 지속
+    @GetMapping("/me")
+    public ResponseEntity<?> me(HttpSession session) {
+        Object uno = session.getAttribute(LOGIN_NO);
+        if (uno == null) return ResponseEntity.status(401).build();
+        Long memberNo = Long.valueOf(uno.toString());
+        LoginResponseDto dto = memberService.getMe(memberNo);
+        return ResponseEntity.ok(dto);
+    }
+
+
 }

--- a/BE/src/main/java/com/goldSys/BE/member/dto/ExistsResponseDto.java
+++ b/BE/src/main/java/com/goldSys/BE/member/dto/ExistsResponseDto.java
@@ -1,0 +1,15 @@
+package com.goldSys.BE.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExistsResponseDto {
+    private int exists;
+    public static ExistsResponseDto of(boolean b) {
+        return new ExistsResponseDto(b ? 1 : 0);
+    }
+}

--- a/BE/src/main/java/com/goldSys/BE/member/dto/MemberAssetDto.java
+++ b/BE/src/main/java/com/goldSys/BE/member/dto/MemberAssetDto.java
@@ -1,0 +1,12 @@
+package com.goldSys.BE.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberAssetDto {
+    private Long memberNo;
+    private Long balance;
+    public static MemberAssetDto of(Long memberNo, Long balance){ return new MemberAssetDto(memberNo, balance); }
+}

--- a/BE/src/main/java/com/goldSys/BE/member/dto/SendEmailCodeRequestDto.java
+++ b/BE/src/main/java/com/goldSys/BE/member/dto/SendEmailCodeRequestDto.java
@@ -1,0 +1,14 @@
+package com.goldSys.BE.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SendEmailCodeRequestDto {
+    @JsonAlias({"email","memberEmail"})
+    private String memberEmail;
+}

--- a/BE/src/main/java/com/goldSys/BE/member/dto/SignupRequestDto.java
+++ b/BE/src/main/java/com/goldSys/BE/member/dto/SignupRequestDto.java
@@ -1,0 +1,13 @@
+package com.goldSys.BE.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SignupRequestDto {
+    private String memberId;
+    private String memberPwd;
+    private String memberName;
+    private String memberEmail;
+}

--- a/BE/src/main/java/com/goldSys/BE/member/dto/SignupResponseDto.java
+++ b/BE/src/main/java/com/goldSys/BE/member/dto/SignupResponseDto.java
@@ -5,11 +5,10 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class LoginResponseDto {
-    private int memberNo;
+public class SignupResponseDto {
+    private int   memberNo;
     private String memberId;
     private String memberName;
     private String memberEmail;
     private String memberRole;
-    private Long balance;
 }

--- a/BE/src/main/java/com/goldSys/BE/member/dto/VerifyEmailCodeRequestDto.java
+++ b/BE/src/main/java/com/goldSys/BE/member/dto/VerifyEmailCodeRequestDto.java
@@ -1,0 +1,15 @@
+package com.goldSys.BE.member.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class VerifyEmailCodeRequestDto {
+    @JsonAlias({"email","memberEmail"})
+    private String memberEmail;
+    private String code;
+}

--- a/BE/src/main/java/com/goldSys/BE/member/entity/MemberAsset.java
+++ b/BE/src/main/java/com/goldSys/BE/member/entity/MemberAsset.java
@@ -1,0 +1,48 @@
+// com.goldSys.BE.asset.entity.MemberAsset.java
+package com.goldSys.BE.member.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "member_asset")
+public class MemberAsset {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "asset_id")
+    private Long assetId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_no", nullable = false)
+    private Member member;
+
+    @Column(name = "balance", nullable = false)
+    private Long balance;
+
+    @Column(name = "created_at", updatable = false,
+            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at",
+            columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) createdAt = LocalDateTime.now();
+        if (updatedAt == null) updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/BE/src/main/java/com/goldSys/BE/member/entity/MemberAuth.java
+++ b/BE/src/main/java/com/goldSys/BE/member/entity/MemberAuth.java
@@ -1,0 +1,10 @@
+package com.goldSys.BE.member.entity;
+
+import lombok.Data;
+
+@Data
+public class MemberAuth {
+    private Long no;         // PK
+    private String memberId; // FK (회원 아이디)
+    private String auth;     // 권한
+}

--- a/BE/src/main/java/com/goldSys/BE/member/repository/MemberAssetRepository.java
+++ b/BE/src/main/java/com/goldSys/BE/member/repository/MemberAssetRepository.java
@@ -1,0 +1,17 @@
+package com.goldSys.BE.member.repository;
+
+import com.goldSys.BE.member.entity.MemberAsset;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface MemberAssetRepository extends JpaRepository<MemberAsset, Long> {
+    boolean existsByMember_MemberNo(Long memberNo);
+    Optional<MemberAsset> findByMember_MemberNo(Long memberNo);
+
+    @Query("select a from MemberAsset a where a.member.memberNo = :memberNo")
+    Optional<MemberAsset> findByMemberNo(@Param("memberNo") Long memberNo); // ← 쓰고 싶으면 이렇게
+
+}

--- a/BE/src/main/java/com/goldSys/BE/member/repository/MemberRepository.java
+++ b/BE/src/main/java/com/goldSys/BE/member/repository/MemberRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByMemberId(String memberId);
+    Optional<Member> findByMemberEmail(String memberEmail);
 }

--- a/BE/src/main/java/com/goldSys/BE/member/service/EmailVerificationService.java
+++ b/BE/src/main/java/com/goldSys/BE/member/service/EmailVerificationService.java
@@ -1,0 +1,6 @@
+package com.goldSys.BE.member.service;
+
+public interface EmailVerificationService {
+    void sendCode(String email);
+    boolean verifyCode(String email, String code);
+}

--- a/BE/src/main/java/com/goldSys/BE/member/service/MemberAssetService.java
+++ b/BE/src/main/java/com/goldSys/BE/member/service/MemberAssetService.java
@@ -1,0 +1,8 @@
+package com.goldSys.BE.member.service;
+
+import com.goldSys.BE.member.dto.MemberAssetDto;
+
+public interface MemberAssetService {
+    MemberAssetDto getOrCreateDefault(Long memberNo);
+    MemberAssetDto getBalance(Long memberNo);
+}

--- a/BE/src/main/java/com/goldSys/BE/member/service/MemberService.java
+++ b/BE/src/main/java/com/goldSys/BE/member/service/MemberService.java
@@ -2,8 +2,24 @@ package com.goldSys.BE.member.service;
 
 import com.goldSys.BE.member.dto.LoginRequestDto;
 import com.goldSys.BE.member.dto.LoginResponseDto;
+import com.goldSys.BE.member.dto.SignupRequestDto;
+import com.goldSys.BE.member.dto.SignupResponseDto;
 
 public interface MemberService {
+    boolean checkId(String memberId);
+    boolean checkEmail(String memberEmail);
+
+    SignupResponseDto join(SignupRequestDto req, String defaultRole);
+
     LoginResponseDto login(LoginRequestDto req);
+
     void updateLastLogin(String memberId);
+
+    void updatePassword(String memberId, String currentPwd, String newPwd);
+
+    void deleteAccount(String memberId, String password);
+
+    void forgotPassword(String memberId, String email);
+
+    LoginResponseDto getMe(Long memberNo);
 }

--- a/BE/src/main/java/com/goldSys/BE/member/service/impl/EmailVerificationServiceImpl.java
+++ b/BE/src/main/java/com/goldSys/BE/member/service/impl/EmailVerificationServiceImpl.java
@@ -1,0 +1,79 @@
+// src/main/java/com/shinhan/backend/member/service/impl/EmailVerificationServiceImpl.java
+package com.goldSys.BE.member.service.impl;
+
+import com.goldSys.BE.member.service.EmailVerificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@RequiredArgsConstructor
+public class EmailVerificationServiceImpl implements EmailVerificationService {
+    private static final int TTL_MIN = 3;
+    private static final int RESEND_COOLDOWN_SEC = 10;
+
+    private final JavaMailSender mailSender;
+    private final PasswordEncoder passwordEncoder;
+    private final SecureRandom rnd = new SecureRandom();
+
+    private static class Item {
+        final String hash;
+        final LocalDateTime exp;
+        final LocalDateTime sent;
+        final boolean verified;
+        Item(String h, LocalDateTime e, LocalDateTime s, boolean v){ this.hash=h; this.exp=e; this.sent=s; this.verified=v; }
+    }
+    private final Map<String, Item> store = new ConcurrentHashMap<>();
+
+    @Override
+    public void sendCode(String emailRaw) {
+        String email = normalize(emailRaw);
+        if (email.isEmpty()) return;
+
+        Item p = store.get(email);
+        if (p != null && p.sent.plusSeconds(RESEND_COOLDOWN_SEC).isAfter(LocalDateTime.now())) return;
+
+        String code = String.format("%06d", rnd.nextInt(1_000_000));
+        String hash = passwordEncoder.encode(code);
+        LocalDateTime now = LocalDateTime.now();
+        store.put(email, new Item(hash, now.plusMinutes(TTL_MIN), now, false));
+
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setTo(email);
+        msg.setSubject("[캡스톤] 이메일 인증코드");
+        msg.setText("인증코드: " + code + " (3분 이내 입력)");
+        mailSender.send(msg);
+    }
+
+    @Override
+    public boolean verifyCode(String emailRaw, String code) {
+        String email = normalize(emailRaw);
+        if (email.isEmpty() || code == null || code.isBlank()) return false;
+
+        Item it = store.get(email);
+        if (it == null || it.verified || LocalDateTime.now().isAfter(it.exp)) return false;
+
+        boolean ok = passwordEncoder.matches(code, it.hash);
+        if (ok) store.put(email, new Item(it.hash, it.exp, it.sent, true));
+        return ok;
+    }
+
+    @Scheduled(fixedRate = 300_000)
+    void cleanup() {
+        LocalDateTime now = LocalDateTime.now();
+        store.entrySet().removeIf(e -> now.isAfter(e.getValue().exp));
+    }
+
+    private static String normalize(String email) {
+        return email == null ? "" : email.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/BE/src/main/java/com/goldSys/BE/member/service/impl/MemberAssetServiceImpl.java
+++ b/BE/src/main/java/com/goldSys/BE/member/service/impl/MemberAssetServiceImpl.java
@@ -1,0 +1,38 @@
+package com.goldSys.BE.member.service.impl;
+
+import com.goldSys.BE.member.dto.MemberAssetDto;
+import com.goldSys.BE.member.entity.Member;
+import com.goldSys.BE.member.entity.MemberAsset;
+import com.goldSys.BE.member.repository.MemberAssetRepository;
+import com.goldSys.BE.member.repository.MemberRepository;
+import com.goldSys.BE.member.service.MemberAssetService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberAssetServiceImpl implements MemberAssetService {
+    private final MemberAssetRepository assetRepo;
+    private final MemberRepository memberRepo;
+    private static final long DEFAULT_BALANCE = 600_000L;
+
+    @Override @Transactional
+    public MemberAssetDto getOrCreateDefault(Long memberNo) {
+        return assetRepo.findByMember_MemberNo(memberNo)
+                .map(a -> MemberAssetDto.of(memberNo, a.getBalance()))
+                .orElseGet(() -> {
+                    Member m = memberRepo.findById(memberNo).orElseThrow(() -> new IllegalArgumentException("회원 없음"));
+                    MemberAsset a = MemberAsset.builder().member(m).balance(DEFAULT_BALANCE).build();
+                    assetRepo.save(a);
+                    return MemberAssetDto.of(memberNo, DEFAULT_BALANCE);
+                });
+    }
+
+    @Override @Transactional(readOnly = true)
+    public MemberAssetDto getBalance(Long memberNo) {
+        return assetRepo.findByMember_MemberNo(memberNo)
+                .map(a -> MemberAssetDto.of(memberNo, a.getBalance()))
+                .orElseThrow(() -> new IllegalArgumentException("자산 없음"));
+    }
+}

--- a/BE/src/main/java/com/goldSys/BE/member/service/impl/MemberServiceImpl.java
+++ b/BE/src/main/java/com/goldSys/BE/member/service/impl/MemberServiceImpl.java
@@ -1,17 +1,21 @@
 package com.goldSys.BE.member.service.impl;
 
-import com.goldSys.BE.member.dto.LoginRequestDto;
-import com.goldSys.BE.member.dto.LoginResponseDto;
+import com.goldSys.BE.member.dto.*;
 import com.goldSys.BE.member.entity.Member;
+import com.goldSys.BE.member.entity.MemberAsset;
 import com.goldSys.BE.member.repository.MemberRepository;
+import com.goldSys.BE.member.service.MemberAssetService;
 import com.goldSys.BE.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.security.SecureRandom;
 import java.time.LocalDateTime;
 
 @Service
@@ -20,30 +24,195 @@ public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository repo;
     private final PasswordEncoder encoder;
+    private final JavaMailSender mailSender;
+    private final MemberAssetService assetService; // 주입
 
+
+    // ====================
+    // 회원가입
+    // ====================
     @Override
-    @Transactional(readOnly = true)
-    public LoginResponseDto login(LoginRequestDto req) {
-        Member m = repo.findByMemberId(req.getMemberId())
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "존재하지 않는 사용자"));
-        if (!encoder.matches(req.getMemberPwd(), m.getMemberPwd())) {
-            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "비밀번호 불일치");
-        }
-        return new LoginResponseDto(
-                m.getMemberNo().intValue(),
-                m.getMemberId(),
-                m.getMemberName(),
-                m.getMemberEmail(),
-                m.getMemberRole()
+    @Transactional
+    public SignupResponseDto join(SignupRequestDto req, String defaultRole) {
+        // 중복 체크
+        if (repo.findByMemberId(req.getMemberId()).isPresent())
+            throw new IllegalArgumentException("DUPLICATE_ID");
+        if (repo.findByMemberEmail(req.getMemberEmail()).isPresent())
+            throw new IllegalArgumentException("DUPLICATE_EMAIL");
+
+        // 엔티티 생성
+        Member m = Member.builder()
+                .memberId(req.getMemberId())
+                .memberPwd(encoder.encode(req.getMemberPwd()))
+                .memberName(req.getMemberName())
+                .memberEmail(req.getMemberEmail())
+                .memberRole(defaultRole != null ? defaultRole : "ROLE_USER")
+                .memberIsActive(true) // 이메일 인증은 프론트에서 끝나고 넘어옴
+                .memberCreatedAt(LocalDateTime.now())
+                .memberUpdatedAt(LocalDateTime.now())
+                .build();
+
+        // 저장
+        Member saved = repo.save(m);
+
+        return new SignupResponseDto(
+                saved.getMemberNo().intValue(),
+                saved.getMemberId(),
+                saved.getMemberName(),
+                saved.getMemberEmail(),
+                saved.getMemberRole()
         );
     }
 
+    // ====================
+    // 로그인
+    // ====================
+    @Override
+    @Transactional
+    public LoginResponseDto login(LoginRequestDto req) {
+        Member member = repo.findByMemberId(req.getMemberId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.UNAUTHORIZED, "존재하지 않는 사용자"));
+
+        if (!encoder.matches(req.getMemberPwd(), member.getMemberPwd())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "비밀번호 불일치");
+        }
+        if (!member.getMemberIsActive()) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "이메일 인증 필요");
+        }
+
+        // 첫 로그인 자산 지급 처리
+        assetService.getOrCreateDefault(member.getMemberNo());
+        Long balance = assetService.getOrCreateDefault(member.getMemberNo()).getBalance();
+
+        return new LoginResponseDto(
+                member.getMemberNo().intValue(),
+                member.getMemberId(),
+                member.getMemberName(),
+                member.getMemberEmail(),
+                member.getMemberRole(),
+                balance
+        );
+    }
+
+    // ====================
+    // 최근 로그인 갱신
+    // ====================
     @Override
     @Transactional
     public void updateLastLogin(String memberId) {
         Member m = repo.findByMemberId(memberId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자 없음"));
-        m.setMemberLastLoginAt(LocalDateTime.now());  // 필드명과 setter 일치
+        m.setMemberLastLoginAt(LocalDateTime.now());
     }
 
+    // ====================
+    // 아이디/이메일 중복 체크
+    // ====================
+    @Override
+    public boolean checkId(String memberId) {
+        if (memberId == null || memberId.isBlank()) return true;
+        return repo.findByMemberId(memberId.trim()).isPresent();
+    }
+
+    @Override
+    public boolean checkEmail(String memberEmail) {
+        if (memberEmail == null || memberEmail.isBlank()) return true;
+        return repo.findByMemberEmail(memberEmail.trim()).isPresent();
+    }
+
+    // ====================
+    // 비밀번호 초기화(임시 비번 발급)
+    // ====================
+    @Override
+    @Transactional
+    public void forgotPassword(String memberId, String memberEmail) {
+        if (memberId == null || memberId.isBlank() || memberEmail == null || memberEmail.isBlank()) {
+            throw new IllegalArgumentException("아이디 또는 이메일 불일치");
+        }
+
+        Member m = repo.findByMemberId(memberId.trim())
+                .filter(user -> user.getMemberEmail().equalsIgnoreCase(memberEmail.trim()))
+                .orElseThrow(() -> new IllegalArgumentException("아이디 또는 이메일 불일치"));
+
+        String tempPassword = generatePassword(12);
+        String encodedPassword = encoder.encode(tempPassword);
+        m.setMemberPwd(encodedPassword);
+
+        // 메일 발송
+        SimpleMailMessage msg = new SimpleMailMessage();
+        msg.setTo(m.getMemberEmail());
+        msg.setSubject("임시 비밀번호 안내");
+        msg.setText("임시 비밀번호: " + tempPassword + "\n로그인 후 반드시 비밀번호를 변경하세요.");
+        mailSender.send(msg);
+    }
+
+    // ====================
+    // 비밀번호 변경
+    // ====================
+    @Override
+    @Transactional
+    public void updatePassword(String memberId, String currentPwd, String newPwd) {
+        Member m = repo.findByMemberId(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+
+        if (!encoder.matches(currentPwd, m.getMemberPwd())) {
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+        }
+        if (encoder.matches(newPwd, m.getMemberPwd())) {
+            throw new IllegalArgumentException("이전과 동일한 비밀번호는 사용할 수 없습니다.");
+        }
+
+        m.setMemberPwd(encoder.encode(newPwd));
+    }
+
+    // ====================
+    // 회원 탈퇴
+    // ====================
+    @Override
+    @Transactional
+    public void deleteAccount(String memberId, String currentPwd) {
+        Member m = repo.findByMemberId(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+
+        if (!encoder.matches(currentPwd, m.getMemberPwd())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        m.setMemberIsActive(false);
+        m.setMemberDeletedAt(LocalDateTime.now());
+    }
+
+    // ====================
+    // 임시 비밀번호 생성 유틸
+    // ====================
+    private String generatePassword(int length) {
+        String chars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789!@#$%^&*?";
+        SecureRandom rnd = new SecureRandom();
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(chars.charAt(rnd.nextInt(chars.length())));
+        }
+        return sb.toString();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public LoginResponseDto getMe(Long memberNo) {
+        // repo = MemberRepository (이미 필드로 주입돼 있음)
+        Member m = repo.findById(memberNo)
+                .orElseThrow(() -> new IllegalArgumentException("member not found"));
+
+
+        Long balance = assetService.getOrCreateDefault(memberNo).getBalance();
+
+        return new LoginResponseDto(
+                m.getMemberNo().intValue(),
+                m.getMemberId(),
+                m.getMemberName(),
+                m.getMemberEmail(),
+                m.getMemberRole(),
+                balance
+        );
+    }
 }
+

--- a/BE/src/main/resources/application.properties
+++ b/BE/src/main/resources/application.properties
@@ -6,3 +6,11 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
+
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=seunghi0510@gmail.com
+spring.mail.password=lsgjlgzutvrqlxbk
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true
+spring.mail.default-encoding=UTF-8

--- a/BE/src/main/resources/application.properties
+++ b/BE/src/main/resources/application.properties
@@ -7,10 +7,3 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 
-spring.mail.host=smtp.gmail.com
-spring.mail.port=587
-spring.mail.username=seunghi0510@gmail.com
-spring.mail.password=lsgjlgzutvrqlxbk
-spring.mail.properties.mail.smtp.auth=true
-spring.mail.properties.mail.smtp.starttls.enable=true
-spring.mail.default-encoding=UTF-8

--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -12,6 +12,7 @@
         "react": "^19.1.1",
         "react-calendar": "^6.0.0",
         "react-dom": "^19.1.1",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.9.2",
         "recharts": "^3.2.1"
       },
@@ -3142,6 +3143,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/FE/package.json
+++ b/FE/package.json
@@ -14,6 +14,7 @@
     "react": "^19.1.1",
     "react-calendar": "^6.0.0",
     "react-dom": "^19.1.1",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.9.2",
     "recharts": "^3.2.1"
   },

--- a/FE/src/App.jsx
+++ b/FE/src/App.jsx
@@ -1,7 +1,9 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { useEffect, useState } from "react";
 import "./App.css";
+import Navigation from "./components/Navigation";
 
-// 페이지 불러오기
+// 페이지들 import
 import OnBoarding from "./pages/OnBoarding/OnBoarding";
 import Simulation from "./pages/Simulation/Simulation";
 import History from "./pages/History/History";
@@ -16,20 +18,56 @@ import Signup from "./pages/Login/Signup";
 import ChangePassword from "./pages/Login/ChangePassword";
 import DeleteAccount from "./pages/Login/DeleteAccount";
 
+function AppInner() {
+  const [auth, setAuth] = useState(null);
 
+  // 앱 시작 시 /api/auth/me 호출 → 로그인 상태 복구
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await fetch("http://localhost:8080/api/auth/me", {
+          credentials: "include", // 세션 쿠키 포함
+        });
+        if (res.ok) {
+          const user = await res.json();
+          setAuth(user); // {memberId, memberName, memberEmail, balance, ...}
+        } else {
+          setAuth(null);
+        }
+      } catch (err) {
+        console.error("auth/me 확인 실패", err);
+        setAuth(null);
+      }
+    })();
+  }, []);
 
-function App() {
+  const onLogout = async () => {
+    try {
+      await fetch("http://localhost:8080/api/auth/logout", {
+        method: "POST",
+        credentials: "include",
+      });
+    } finally {
+      setAuth(null);
+    }
+  };
+
   return (
-    <BrowserRouter>
+    <>
+      <Navigation
+        isAuthed={!!auth}
+        memberId={auth?.memberId}
+        memberName={auth?.memberName}
+        memberEmail={auth?.memberEmail}
+        balance={auth?.balance}
+        onLogout={onLogout}
+      />
       <Routes>
-        {/* 제일 첫 시작 (/) → OnBoarding */}
         <Route path="/" element={<OnBoarding />} />
-        
-        {/* 다른 페이지들 */}
         <Route path="/simulation" element={<Simulation />} />
         <Route path="/history" element={<History />} />
         <Route path="/glossary" element={<Glossary />} />
-        <Route path="/login" element={<Login />} />
+        <Route path="/login" element={<Login onAuthed={setAuth} />} />
         <Route path="/forgotPassword" element={<ForgotPassword />} />
         <Route path="/signup" element={<Signup />} />
         <Route path="/changePassword" element={<ChangePassword />} />
@@ -38,11 +76,15 @@ function App() {
         <Route path="/simulation/step2" element={<Step2 />} />
         <Route path="/simulation/step3" element={<Step3 />} />
         <Route path="/simulation/result" element={<Result />} />
-
-
       </Routes>
-    </BrowserRouter>
+    </>
   );
 }
 
-export default App;
+export default function App() {
+  return (
+    <BrowserRouter>
+      <AppInner />
+    </BrowserRouter>
+  );
+}

--- a/FE/src/components/Navigation.css
+++ b/FE/src/components/Navigation.css
@@ -49,3 +49,104 @@
 .nav-login a:hover {
   color: #0066ff;
 }
+
+
+/* 프로필 */
+.profile {
+  position: relative;
+}
+
+.gs-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: #374151;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 4px 10px rgba(0,0,0,.08);
+}
+
+.gs-avatar-text {
+  font-size: 14px;
+}
+
+.gs-menu {
+  position: absolute;
+  right: 0;
+  top: 44px;
+  width: 220px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  box-shadow: 0 16px 34px rgba(0,0,0,.14);
+  padding: 10px;
+  z-index: 100;
+}
+
+.gs-menu-header {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding-bottom: 8px;
+}
+
+.gs-menu-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #374151;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 800;
+}
+
+.gs-menu-meta {
+  min-width: 0;
+}
+.gs-menu-name {
+  font-weight: 700;
+  color: #111827;
+}
+.gs-menu-id {
+  font-size: 12px;
+  color: #6b7280;
+}
+.gs-menu-balance {
+  font-size: 13px;
+  color: #374151;
+  margin-top: 2px;
+}
+
+.gs-menu-divider {
+  height: 1px;
+  background: #f3f4f6;
+  margin: 8px 0;
+}
+
+.gs-menu-item {
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  border-radius: 8px;
+  font-size: 14px;
+  color: #111827;
+}
+.gs-menu-item:hover {
+  background: #f9fafb;
+}
+.gs-menu-item.danger {
+  color: #b91c1c;
+}
+.gs-menu-item.danger:hover {
+  background: #fee2e2;
+}

--- a/FE/src/components/Navigation.jsx
+++ b/FE/src/components/Navigation.jsx
@@ -1,25 +1,94 @@
 // src/components/Navigation.jsx
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import { useState, useRef, useEffect, useMemo } from "react";
+import { FaUserCircle } from "react-icons/fa";
 import "./Navigation.css";
 
-function Navigation() {
+function Navigation({ isAuthed, memberId, memberName, memberEmail, balance, onLogout }) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef(null);
+  const nav = useNavigate();
+
+  const displayName = useMemo(
+    () => (memberName && memberName.trim()) || (memberId && memberId.trim()) || "사용자",
+    [memberName, memberId]
+  );
+  const initials = useMemo(() => {
+    const s = (memberName || memberId || "").trim();
+    return s ? s.slice(0, 1).toUpperCase() : "";
+  }, [memberName, memberId]);
+
+  useEffect(() => {
+    const handler = (e) => { if (menuRef.current && !menuRef.current.contains(e.target)) setOpen(false); };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, []);
+
   return (
     <nav className="nav">
       <div className="nav-container">
-        {/* 로고 */}
         <div className="nav-logo">GoldSim</div>
 
-        {/* 메뉴 */}
         <div className="nav-menu">
           <Link to="/simulation">투자 시뮬레이션</Link>
           <Link to="/history">투자 이력</Link>
           <Link to="/glossary">용어사전</Link>
         </div>
 
-        {/* 로그인 */}
-        <div className="nav-login">
-          <Link to="/login">로그인</Link>
-        </div>
+        {!isAuthed ? (
+          <Link to="/login" className="gs-cta">로그인</Link>
+        ) : (
+          <div className="profile" ref={menuRef}>
+            <button
+              type="button"
+              className="gs-avatar"
+              onClick={() => setOpen(v => !v)}
+              aria-haspopup="menu"
+              aria-expanded={open}
+              title={displayName}
+            >
+              {initials ? <span className="gs-avatar-text">{initials}</span> : <FaUserCircle aria-hidden />}
+            </button>
+
+            {open && (
+              <div className="gs-menu" role="menu">
+                <div className="gs-menu-header">
+                  <div className="gs-menu-avatar">{initials || <FaUserCircle aria-hidden />}</div>
+                  <div className="gs-menu-meta">
+                    <div className="gs-menu-name">{displayName}</div>
+                    {/* 아이디/이메일 노출 규칙 */}
+                    {memberId ? <div className="gs-menu-id">@{memberId}</div> : null}
+                    {memberEmail ? <div className="gs-menu-id">{memberEmail}</div> : null}
+                    {typeof balance === "number" && (
+                      <div className="gs-menu-balance">보유 자산 {Number(balance).toLocaleString()}원</div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="gs-menu-divider" />
+
+                <button
+                  className="gs-menu-item"
+                  onClick={() => { setOpen(false); nav("/changePassword"); }} // 경로 정정
+                >
+                  비밀번호 변경
+                </button>
+                <button
+                  className="gs-menu-item"
+                  onClick={() => { setOpen(false); nav("/deleteAccount"); }}
+                >
+                  회원탈퇴
+                </button>
+                <button
+                  className="gs-menu-item danger"
+                  onClick={() => { setOpen(false); onLogout?.(); }}
+                >
+                  로그아웃
+                </button>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </nav>
   );

--- a/FE/src/pages/History/History.jsx
+++ b/FE/src/pages/History/History.jsx
@@ -165,8 +165,6 @@ export default function HistoryDashboard() {
   const setSize = (s) => setFilters((f) => ({ ...f, size: s, page: 1 }));
 
   return (
-    <>
-      <Navigation />
       <div className="hd hd-page">
         <h1 className="hd-title">과거 이력</h1>
 
@@ -345,6 +343,5 @@ export default function HistoryDashboard() {
           </div>
         </div>
       </div>
-    </>
   );
 }

--- a/FE/src/pages/Login/ChangePassword.jsx
+++ b/FE/src/pages/Login/ChangePassword.jsx
@@ -60,8 +60,6 @@ export default function ChangePassword() {
   }
 
   return (
-    <>
-      <Navigation />
       <div className="login-wrap">
         <div className="login-card">
           <h1 className="title">비밀번호 변경</h1>
@@ -108,6 +106,5 @@ export default function ChangePassword() {
           )}
         </div>
       </div>
-    </>
   );
 }

--- a/FE/src/pages/Login/DeleteAccount.jsx
+++ b/FE/src/pages/Login/DeleteAccount.jsx
@@ -35,8 +35,6 @@ export default function DeleteAccount() {
   }
 
   return (
-    <>
-      <Navigation />
       <div className="login-wrap">
         <div className="login-card">
           <h1 className="title">회원 탈퇴</h1>
@@ -91,6 +89,5 @@ export default function DeleteAccount() {
           )}
         </div>
       </div>
-    </>
   );
 }

--- a/FE/src/pages/Login/ForgotPassword.jsx
+++ b/FE/src/pages/Login/ForgotPassword.jsx
@@ -30,8 +30,6 @@ export default function ForgotPassword() {
   }
 
   return (
-    <>
-      <Navigation />
       <div className="login-wrap">
         <div className="login-card">
           <h1 className="title">비밀번호 찾기</h1>
@@ -66,6 +64,5 @@ export default function ForgotPassword() {
           </div>
         </div>
       </div>
-    </>
   );
 }

--- a/FE/src/pages/Login/Login.jsx
+++ b/FE/src/pages/Login/Login.jsx
@@ -1,92 +1,110 @@
 // src/pages/Login.jsx
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import axios from "axios";
-import Navigation from "../../components/Navigation";
 import "../Login/Login.css";
 
-export default function Login() {
+export default function Login({ onAuthed }) {
+  const nav = useNavigate();
   const [memberId, setMemberId] = useState("");
   const [memberPwd, setMemberPwd] = useState("");
   const [remember, setRemember] = useState(false);
   const [err, setErr] = useState("");
   const [loading, setLoading] = useState(false);
 
+  // 저장된 아이디 불러오기
   useEffect(() => {
     const saved = localStorage.getItem("saved_memberId");
-    if (saved) { setMemberId(saved); setRemember(true); }
+    if (saved) {
+      setMemberId(saved);
+      setRemember(true);
+    }
   }, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setErr(""); setLoading(true);
+    setErr("");
+    setLoading(true);
     try {
-      await axios.post(
+      const res = await axios.post(
         "http://localhost:8080/api/auth/login",
         { memberId, memberPwd },
         { withCredentials: true }
       );
-      if (remember) localStorage.setItem("saved_memberId", memberId);
-      else localStorage.removeItem("saved_memberId");
-      window.location.href = "/";
+      const data = res.data; // { memberId, memberName, balance, ... } 백엔드 DTO
+      onAuthed?.(data);      // App.jsx에서 user 상태 갱신
+
+
+      if (remember) {
+        localStorage.setItem("saved_memberId", memberId);
+      } else {
+        localStorage.removeItem("saved_memberId");
+      }
+
+      nav("/"); // 홈으로 이동
     } catch {
       setErr("아이디 또는 비밀번호가 올바르지 않습니다.");
-    } finally { setLoading(false); }
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
-    <>
-      <Navigation />
-      <div className="login-wrap">
-        <div className="login-card">
-          <h1 className="title">로그인</h1>
-          <form className="form" onSubmit={handleSubmit}>
-            <label className="label" htmlFor="memberId">아이디</label>
+    <div className="login-wrap">
+      <div className="login-card">
+        <h1 className="title">로그인</h1>
+        <form className="form" onSubmit={handleSubmit}>
+          {/* 아이디 */}
+          <label className="label" htmlFor="memberId">아이디</label>
+          <input
+            id="memberId"
+            type="text"
+            className="input"
+            placeholder="아이디"
+            value={memberId}
+            onChange={(e) => setMemberId(e.target.value)}
+            autoComplete="username"
+            required
+          />
+
+          {/* 비밀번호 */}
+          <label className="label" htmlFor="memberPwd">비밀번호</label>
+          <input
+            id="memberPwd"
+            type="password"
+            className="input"
+            placeholder="비밀번호"
+            value={memberPwd}
+            onChange={(e) => setMemberPwd(e.target.value)}
+            autoComplete="current-password"
+            required
+          />
+
+          {/* 아이디 저장 */}
+          <label className="remember">
             <input
-              id="memberId"
-              type="text"
-              className="input"
-              placeholder="아이디"
-              value={memberId}
-              onChange={(e)=>setMemberId(e.target.value)}
-              autoComplete="username"
-              required
+              type="checkbox"
+              checked={remember}
+              onChange={(e) => setRemember(e.target.checked)}
             />
+            아이디 저장
+          </label>
 
-            <label className="label" htmlFor="memberPwd">비밀번호</label>
-            <input
-              id="memberPwd"
-              type="password"
-              className="input"
-              placeholder="비밀번호"
-              value={memberPwd}
-              onChange={(e)=>setMemberPwd(e.target.value)}
-              autoComplete="current-password"
-              required
-            />
+          {/* 에러 메시지 */}
+          {err && <div className="error">{err}</div>}
 
-            <label className="remember">
-              <input
-                type="checkbox"
-                checked={remember}
-                onChange={(e)=>setRemember(e.target.checked)}
-              />
-              아이디 저장
-            </label>
+          {/* 버튼 */}
+          <button type="submit" className="btn" disabled={loading}>
+            {loading ? "로그인 중..." : "로그인"}
+          </button>
+        </form>
 
-            {err && <div className="error">{err}</div>}
-
-            <button type="submit" className="btn" disabled={loading}>
-              {loading ? "로그인 중..." : "로그인"}
-            </button>
-          </form>
-
-          <div className="login-footer">
-            <a className="link" href="/signup">회원가입</a>
-            <span className="dot">·</span>
-            <a className="link" href="/forgotPassword">비밀번호 찾기</a>
-          </div>
+        <div className="login-footer">
+          <a className="link" href="/signup">회원가입</a>
+          <span className="dot">·</span>
+          <a className="link" href="/forgotPassword">비밀번호 찾기</a>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/FE/src/pages/Login/Signup.jsx
+++ b/FE/src/pages/Login/Signup.jsx
@@ -254,8 +254,6 @@ export default function Signup() {
   const canResend = timer <= 0 && !emailSending;
 
   return (
-    <>
-      <Navigation />
       <div className="login-wrap">
         <div className="login-card">
           <h1 className="title">회원가입</h1>
@@ -347,6 +345,5 @@ export default function Signup() {
           </div>
         </div>
       </div>
-    </>
   );
 }

--- a/FE/src/pages/OnBoarding/OnBoarding.jsx
+++ b/FE/src/pages/OnBoarding/OnBoarding.jsx
@@ -6,8 +6,6 @@ import "./OnBoarding.css";
 
 function OnBoarding() {
   return (
-    <>
-      <Navigation />
       <div className="onboarding">
         <h1 className="onboarding-title">
           투자 초보도 이해할 수 있는 금 시세 학습 플랫폼
@@ -16,7 +14,6 @@ function OnBoarding() {
           뉴스와 데이터를 읽고 금 시세 변화를 직접 경험하세요!
         </p>
       </div>
-    </>
   );
 }
 


### PR DESCRIPTION
### 작업 내용
- 네비게이션 드롭다운 UI 추가 (로그인 후 회원 정보 표시 및 로그아웃 메뉴)
- 새로고침 시 세션 유지 기능 구현 (/api/auth/me 연동)
- 회원가입 로직 개선 및 이메일 인증 기능 추가
- App.jsx 구조 개선 (Layout 및 인증 상태 관리 통합)

### 변경된 파일 주요 내역
- BE: MemberController, MemberService, MemberServiceImpl, EmailAuthController 등
- BE: EmailVerificationService, MemberAssetService, DTO 추가
- FE: Navigation.jsx, App.jsx, Login/Signup 관련 페이지 수정
- FE: 로그인 후 드롭다운 표시 및 세션 유지 로직 추가

### 이슈 번호
Closes #14

### 리뷰 포인트
- 세션 유지 로직이 프론트/백 모두 정상적으로 동작하는지 확인 필요
- 이메일 인증 로직이 기존 회원가입 플로우와 자연스럽게 연동되는지 점검
- FE App.jsx에서 상태 관리 방식이 적절한지 검토
